### PR TITLE
Add podman/docker build environment for FPGA toolchain

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,7 @@
+.git
+_build
+verilog_out
+*.fs
+*.opam
+*.json
+*.vcd

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,91 @@
+# Containerfile for the FPGA-exp open-source toolchain (Tang Nano 20K / Gowin GW2A).
+#
+# Builds Yosys, nextpnr-himbaechel (gowin uarch) and openFPGALoader from
+# source, since the toolchain requires features/architectures newer than
+# what Ubuntu 22.04's apt packages ship (see all_projects/project02/Fedora_WSL.md).
+# Also sets up an opam switch with dune + hardcaml for the projects that
+# generate Verilog from OCaml/Hardcaml.
+
+FROM ubuntu:22.04
+
+ARG YOSYS_REF=yosys-0.38
+ARG NEXTPNR_REF=nextpnr-0.7
+ARG OPENFPGALOADER_REF=v0.12.1
+ARG OCAML_VERSION=5.1.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
+# --- system / build dependencies ---------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake git pkg-config \
+        bison flex gperf \
+        libboost-all-dev libeigen3-dev libreadline-dev \
+        tcl-dev libffi-dev zlib1g-dev \
+        libftdi1-dev libhidapi-dev libudev-dev libusb-1.0-0-dev \
+        python3 python3-pip python3-venv \
+        opam m4 unzip curl ca-certificates sudo rsync \
+        gtkwave verilator \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Yosys (from source: guarantees a synth_gowin pass with current cell libs) --
+RUN git clone --recurse-submodules https://github.com/YosysHQ/yosys.git /tmp/yosys \
+    && cd /tmp/yosys \
+    && git checkout ${YOSYS_REF} \
+    && git submodule update --init --recursive \
+    && make -j"$(nproc)" \
+    && make install \
+    && rm -rf /tmp/yosys
+
+# --- nextpnr-himbaechel (gowin micro-architecture) ----------------------
+RUN git clone --recurse-submodules https://github.com/YosysHQ/nextpnr.git /tmp/nextpnr \
+    && cd /tmp/nextpnr \
+    && git checkout ${NEXTPNR_REF} \
+    && git submodule update --init --recursive \
+    && mkdir build && cd build \
+    && cmake .. -DARCH=himbaechel -DHIMBAECHEL_UARCH=gowin -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && rm -rf /tmp/nextpnr
+
+# --- Apycula (provides gowin_pack, used to produce the .fs bitstream) --
+RUN pip3 install --no-cache-dir apycula
+
+# --- openFPGALoader (flashing the Tang Nano 20K over USB) ---------------
+RUN git clone https://github.com/trabucayre/openFPGALoader.git /tmp/openFPGALoader \
+    && cd /tmp/openFPGALoader \
+    && git checkout ${OPENFPGALOADER_REF} \
+    && mkdir build && cd build \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && rm -rf /tmp/openFPGALoader
+
+# --- dedicated non-root build user --------------------------------------
+ARG USERNAME=builder
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME} \
+    && groupadd -f plugdev \
+    && usermod -aG dialout,plugdev ${USERNAME} \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+# --- OCaml / dune / hardcaml toolchain (as builder, no root needed) -----
+RUN opam init --bare --disable-sandboxing -y \
+    && opam switch create default ${OCAML_VERSION} \
+    && eval $(opam env) \
+    && opam install -y dune core \
+        hardcaml hardcaml_waveterm \
+        ppx_jane ppx_inline_test ppx_expect \
+    && opam clean -a -c -s --logs
+
+ENV PATH=/home/builder/.opam/default/bin:$PATH
+RUN echo 'eval $(opam env)' >> /home/builder/.bashrc
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Setting up the Sipeed toolchain
 
 The Sipeed Tang Nano 20K is descrbed here: https://wiki.sipeed.com/hardware/en/tang/tang-nano-20k/nano-20k.html
 
+Building inside a container
+----------------------------
+
+A `Containerfile` and `docker-compose.yml` are provided to build the full
+open-source toolchain (Yosys, nextpnr-himbaechel with the gowin uarch,
+Apycula's `gowin_pack`, openFPGALoader) plus the OCaml/dune/Hardcaml stack
+used by the `*_hardcaml` projects, on top of Ubuntu 22.04. The image runs
+as a dedicated `builder` user with `/home/builder` as its home, and the
+repository is bind-mounted into `/home/builder/FPGA-exp`.
+
+    podman compose build
+    podman compose run --rm fpga-builder
+    # inside the container:
+    cd FPGA-exp/all_projects/project04/led_hardcaml
+    make
+
+`docker compose` works the same way if you'd rather use Docker. To flash a
+board from inside the container, uncomment the USB `devices:` entry in
+`docker-compose.yml` first.
+
 Projects
 --------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# Usage (podman):
+#   podman compose build
+#   podman compose run --rm fpga-builder
+#   # then inside the container, e.g.:
+#   cd FPGA-exp/all_projects/project04/led_hardcaml && make
+#
+# Also works with `docker compose` unmodified.
+
+services:
+  fpga-builder:
+    build:
+      context: .
+      dockerfile: Containerfile
+      args:
+        USER_UID: "${USER_UID:-1000}"
+        USER_GID: "${USER_GID:-1000}"
+    image: fpga-exp-builder:latest
+    container_name: fpga-exp-builder
+    user: builder
+    working_dir: /home/builder
+    volumes:
+      # Mount the repo into the builder's home. Kept as a subdirectory
+      # (not $HOME itself) so it doesn't shadow the opam switch installed
+      # into /home/builder/.opam at image build time.
+      - .:/home/builder/FPGA-exp:Z
+    # Uncomment to allow openFPGALoader to reach the Tang Nano 20K over USB
+    # for flashing (host must expose the device; on rootless podman you may
+    # also need --group-add keep-groups or an equivalent udev rule):
+    # devices:
+    #   - /dev/bus/usb:/dev/bus/usb
+    tty: true
+    stdin_open: true
+    command: ["/bin/bash"]


### PR DESCRIPTION
Containerfile builds Yosys, nextpnr-himbaechel (gowin uarch), Apycula and openFPGALoader from source on Ubuntu 22.04, plus an opam switch with dune/hardcaml, running as a dedicated builder user (home /home/builder). docker-compose.yml mounts the repo into the container for use with podman compose or docker compose.


Claude-Session: https://claude.ai/code/session_01RGcx4ZGXNA33suKmxvyhN6